### PR TITLE
Fix issue when Cplex experiment created with null dataset-id

### DIFF
--- a/simccs_maptool/views.py
+++ b/simccs_maptool/views.py
@@ -368,6 +368,10 @@ def experiment_scenario_dir(request, experiment):
         request, experiment, "Candidate-Network", input_file=True)
     solution = _get_experiment_file(request, experiment, "Cplex-solution")
     dataset_id = _get_experiment_value(experiment, "Dataset-id")
+    # FIXME: users can't specify the dataset id and it has no default, so it may
+    # not be set but we'll just assume that it is Lower48US
+    if not dataset_id:
+        dataset_id = "Lower48US"
     with tempfile.TemporaryDirectory() as datasets_basepath:
         dataset_dir = datasets.get_dataset_dir(dataset_id)
         # Create the scenario directory


### PR DESCRIPTION
If a Cplex experiment is created through "Create Experiment" instead of through Maptool/Build tool, then a user won't be able to specify the "Dataset-id". Without the dataset id, maptool won't be able to generate a candidate network, or shapefiles, etc.

This code change defaults a null "Dataset-id" to "Lower48US" which is generally the only dataset expected for a user uploading their own source and sink files. Long term though we might want to reconsider what would be a good default or whether users should be able to specify this value or not.